### PR TITLE
Restore content about file naming conventions

### DIFF
--- a/chapters/02_planning-for-success.md
+++ b/chapters/02_planning-for-success.md
@@ -229,6 +229,116 @@ structure might include:
 * `coding/` which includes `themes/` and `memos/`
 * `outputs/` which includes `analysis_summaries/` and `reports/`
 
+As an example of how establishing a directory structure (and using naming
+conventions) helps with project organization, consider this project:
+
+:::{figure} /images/AmandaUnorganizedProject.jpg
+:alt: A diagram showing an unorganized directory structure for Amanda's Research Project.
+:width: 600px
+:align: center
+:::
+
+:::{dropdown} Text version of directory structure
+
+```
+Amanda's Research Project/
+├── observations/
+│   ├── 20121103_ra179.7dec12.1_g.fits
+│   ├── 20121103_ra179.7dec12.1_r.fits
+│   ├── 20121103_ra179.7dec12.1_spec.fits
+│   ├── 20121104_ra180.0dec12.1_g.fits
+│   ├── 20121104_ra180.0dec12.1_r.fits
+│   ├── 20121104_ra180.0dec12.1_spec.fits
+│   ├── galaxy1_g_crop.fits
+│   ├── galaxy1_r_crop.fits
+│   ├── galaxy1_spec_restframe.fits
+│   ├── galaxy2_g_crop.fits
+│   ├── galaxy2_r_crop.fits
+│   └── galaxy2_spec_restframe.fits
+├── 1303.7762.pdf
+├── 2dfft.py
+├── BHmass.py
+├── E&M class notes
+├── mass & pitch angle scatter.png
+├── paper on mass estimates.pdf
+├── redshift(z)histogram
+├── results
+└── spiral paper.pdf
+```
+:::
+
+This project appears to have grown organically--the directory structure and
+naming conventions are not consistent. Because of that, it's not obvious what
+this project is about and what it contains. Many of the file names are unclear
+and would require additional context to understand their purpose (e.g., `spiral
+paper.pdf`). This makes it difficult for anyone interacting with the project to
+be able to find a file and know why and how to use it. The directory structure
+is shallow, so files that serve different purposes are interspersed together.
+Additionally, several file names include spaces and special characters, which
+can cause problems with some software.
+
+Here's a cleaned up version of the same project:
+
+:::{figure} /images/AmandaCorrectedStructure.jpg
+:alt: A diagram showing the directory structure for the BlackHoleMass project.
+:width: 600px
+:align: center
+:::
+
+:::{dropdown} Text version of directory structure
+
+```
+BlackHoleMass_SpiralGalaxy/
+├── analysis/
+│   ├── plots/
+│   │   ├── mass_pitchangle_scatter.png
+│   │   └── redshift_histogram.png
+│   ├── 2dfft.py
+│   ├── BHmass.py
+│   ├── results.csv
+│   └── README.txt
+├── data/
+│   ├── processed/
+│   │   ├── galaxy1_g_crop.fits
+│   │   ├── galaxy1_r_crop.fits
+│   │   ├── galaxy1_spec_restframe.fits
+│   │   ├── galaxy2_g_crop.fits
+│   │   ├── galaxy2_r_crop.fits
+│   │   ├── galaxy2_spec_restframe.fits
+│   │   ├── README.txt
+│   │   └── README_methods.txt
+│   └── raw/
+│       ├── 20121103_ra179.7dec12.1_g.fits
+│       ├── 20121103_ra179.7dec12.1_r.fits
+│       ├── 20121103_ra179.7dec12.1_spec.fits
+│       ├── 20121104_ra180.0dec12.1_g.fits
+│       ├── 20121104_ra180.0dec12.1_r.fits
+│       ├── 20121104_ra180.0dec12.1_spec.fits
+│       └── README.txt
+├── literature/
+│   ├── BHmass_pitch.bib
+│   ├── KormandyHo2013.pdf
+│   ├── Lusso2010.pdf
+│   └── Vertergaard2006.pdf
+└── README.txt
+```
+:::
+
+We can see a number of changes to the project to make it more human and machine
+readable. This new folder structure helps us better navigate and understand how
+files relate to one another. The inclusion of `README.txt` files is also
+important, as they provide context about the project and its the associated
+files. The file names are now machine-readable (`mass & pitch angle
+scatter.png` to `mass_pitchangle_scatter.png`) and explain more about the
+contents of the file (`spiral paper.pdf` to `KormandyHo2013.pdf`). Even without
+a background in astronomical physics, it is much easier to understand the
+purpose of the files for the project.
+
+This example was adapted from [Schilling et al. 2025][ou-osf-files].
+
+[ou-osf-files]: https://osf.io/ukq6b/overview
+
+
 :::{seealso}
 For more examples of directory structures, see:
 
@@ -280,112 +390,6 @@ provides an overview of these basic principles and how to apply them when
 naming your files and directories.
 
 [rdm-guide-filenaming]: https://guides.library.ucdavis.edu/data-management/file-naming
-
-For example, consider this project:
-
-```{image} /images/AmandaUnorganizedProject.jpg
-:alt: A diagram showing an unorganized directory structure for Amanda's Research Project.
-:width: 600px
-:align: center
-```
-
-```{dropdown} Text version of directory structure
-* **Amanda's Research Project/**
-    * **observations/**
-        * 20121103_ra179.7dec12.1_g.fits
-        * 20121103_ra179.7dec12.1_r.fits
-        * 20121103_ra179.7dec12.1_spec.fits
-        * 20121104_ra180.0dec12.1_g.fits
-        * 20121104_ra180.0dec12.1_r.fits
-        * 20121104_ra180.0dec12.1_spec.fits
-        * galaxy1_g_crop.fits
-        * galaxy1_r_crop.fits
-        * galaxy1_spec_restframe.fits
-        * galaxy2_g_crop.fits
-        * galaxy2_r_crop.fits
-        * galaxy2_spec_restframe.fits
-    * 1303.7762.pdf
-    * 2dfft.py
-    * BHmass.py
-    * E&M class notes
-    * mass & pitch angle scatter.png
-    * paper on mass estimates.pdf
-    * redshift(z)histogram
-    * results
-    * spiral paper.pdf
-```
-
-<!-- FIXME: backticks around file names -->
-This directory appears to have grown organically--there is no consistent file
-organization or naming convention. Because of that, it's not obvious what this
-project is about and what it contains. Many of the file names are unclear and
-would require additional context to understand their purpose (e.g., "spiral
-paper.pdf"). This makes it difficult for anyone interacting with the project to
-be able to find a file and know why and how to use it. The directory structure
-is shallow, meaning that files serving different purposes are interspersed
-together. Additionally, several file names include spaces and special
-characters, which can cause problems for those using the files with analysis
-and other software.
-
-
-Here is a cleaned up version of this same project:
-
-```{image} /images/AmandaCorrectedStructure.jpg
-:alt: A diagram showing the directory structure for the BlackHoleMass project.
-:width: 600px
-:align: center
-```
-
-```{dropdown} Text version of directory structure
-* **BlackHoleMass_SpiralGalaxy/**
-  * **analysis/**
-    * **plots/**
-      * mass_pitchangle_scatter.png
-      * redshift_histogram.png
-    * 2dfft.py
-    * BHmass.py
-    * results.csv
-    * README.txt
-  * **data/**
-    * **processed/**
-      * galaxy1_g_crop.fits
-      * galaxy1_r_crop.fits
-      * galaxy1_spec_restframe.fits
-      * galaxy2_g_crop.fits
-      * galaxy2_r_crop.fits
-      * galaxy2_spec_restframe.fits
-      * README.txt
-      * README_methods.txt
-    * **raw/**
-      * 20121103_ra179.7dec12.1_g.fits
-      * 20121103_ra179.7dec12.1_r.fits
-      * 20121103_ra179.7dec12.1_spec.fits
-      * 20121104_ra180.0dec12.1_g.fits
-      * 20121104_ra180.0dec12.1_r.fits
-      * 20121104_ra180.0dec12.1_spec.fits
-      * README.txt
-  * **literature/**
-    * BHmass_pitch.bib
-    * KormandyHo2013.pdf
-    * Lusso2010.pdf
-    * Vertergaard2006.pdf
-  * README.txt
-```
-
-We can see a number of changes and choices the project author made to the
-project to make it more human and machine readable. This new folder structure
-helps us better navigate and understand how files relate to one another. The
-the inclusion of README.txt files is also important, as they contain additional
-context regarding the contents, origin and purpose of the associated files. The
-author also changed the file names to be more machine readable ("mass & pitch
-angle scatter.png" to "mass_pitchangle_scatter.png") and added names that
-explain more about the contents of the file ("spiral paper.pdf" to
-"KormandyHo2013.pdf"). Even without a background in astronomical physics, it is
-much easier to understand the purpose of the files for the project.
-
-Adapted from [Schilling, Amanda, et al. “Managing Research Files.” OSF, 7 Feb. 2025. Web.][ou-osf-files]
-
-[ou-osf-files]: https://osf.io/ukq6b/overview
 
 :::{tip}
 Before starting your project, it's a good idea to check if there are any

--- a/chapters/02_planning-for-success.md
+++ b/chapters/02_planning-for-success.md
@@ -377,19 +377,37 @@ Different contexts often benefit from different naming conventions. For
 instance, it's usually a helpful to have separate naming conventions for files
 and for code.
 
-
-### File and Directory Names
-
-:::{important}
-Choose filenames that are human-readable, machine-readable, and have a
-meaningful order when sorted alphabetically.
+:::{figure} /images/xkcd_iso_8601.png
+---
+name: xkcd-iso-8601
+alt:
+---
+"ISO 8601" from ["xkcd"][xkcd] by Randall Munroe ([license][xkcd-license]).
 :::
 
-The UC Davis Library [Research Data Managment Guide][rdm-guide-filenaming]
-provides an overview of these basic principles and how to apply them when
-naming your files and directories.
+[xkcd]: https://xkcd.com/
+[xkcd-license]: https://xkcd.com/license.html
 
-[rdm-guide-filenaming]: https://guides.library.ucdavis.edu/data-management/file-naming
+Choose filenames that are human-readable, machine-readable, and have a
+meaningful order when sorted alphabetically. We recommend the following rules
+for naming files:
+
++ Make the name descriptive (can someone guess the contents from the name?)
++ Avoid spaces, punctuation, accented characters, and other special characters
++ Use lowercase unless there is a compelling reason for uppercase
++ Use underscores `_` to separate fields (distinct pieces of information, such
+  as dates and descriptions)
++ Use dashes `-` to separate words within fields
++ Write dates and times in [ISO 8601 format][iso-8601], which orders units from
+  largest to smallest (for example, year-month-day as in `2023-09-20`; also see
+  {numref}`Figure %s<xkcd-iso-8601>`)
++ Pad numbers with leading zeros to the width of the largest number you
+  anticipate
+
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+
+DataLab follows these rules for almost all projects, with some simplifying
+exceptions around how we use underscores and dashes.
 
 :::{tip}
 Before starting your project, it's a good idea to check if there are any
@@ -406,11 +424,14 @@ presentation][how-to-name-files].
 
 Prefer an essay over a presentation? See Douglas MacDonald's [On Naming
 Things][on-naming-things].
+
+See the [File Naming Conventions][rdm-guide-filenaming] page in the Library's
+Research Data Management Guide for more suggestions about naming conventions.
 :::
 
 [how-to-name-files]: https://github.com/jennybc/how-to-name-files
 [on-naming-things]: https://www.douganddata.com/2022/07/on-naming-things/
-
+[rdm-guide-filenaming]: https://guides.library.ucdavis.edu/data-management/file-naming
 
 <!-- TODO: Think "Open" -->
 (sec-prefer-open-source-software)=

--- a/chapters/02_planning-for-success.md
+++ b/chapters/02_planning-for-success.md
@@ -187,6 +187,13 @@ You may also find these external guides useful:
 (establish-directory-structure)=
 ## Establish a Directory Structure
 
+::::{margin}
+::::{note}
+A **directory** is a container for the files on your computer. It can be
+helpful to think of directories like the folders in a filing cabinet.
+::::
+:::
+
 Create a separate, dedicated directory, often called a **repository**, for each
 of your projects. Store everything related to the project there. This will make
 it easier to find files and also to share specific projects with others. Use
@@ -226,10 +233,13 @@ structure might include:
 For more examples of directory structures, see:
 
 * DataLab's [Project Template][datalab-template]
+* The [Directory Structures][libguide-directory] page in the Library's Research
+  Data Management Guide
 * [Cookiecutter Data Science][cookiecutter]
 * The Turing Way's [Creating Project Repositories guide][turing-repo]
 
 [datalab-template]: https://github.com/datalab-dev/template_project
+[libguide-directory]: https://guides.library.ucdavis.edu/data-management/directories
 [cookiecutter]: https://github.com/drivendata/cookiecutter-data-science
 [turing-repo]: https://the-turing-way.netlify.app/project-design/project-repo/project-repo-advanced
 :::

--- a/chapters/03_daily-habits-for-everyone.md
+++ b/chapters/03_daily-habits-for-everyone.md
@@ -129,24 +129,6 @@ since they're convenient for data entry.
 ## Write & Maintain READMEs
 
 <!-- FIXME: backticks around file names -->
-::::{margin}
-::::{note}
-A **directory** is a container for the files on your computer. It can be
-helpful to think of directories like the folders in a filing cabinet. Keeping
-your file system organized is important because it makes finding and accessing
-a specific file a lot easier, and enables you to more easily backup and share
-your work on a project. A directory can have multiple directories nested within
-it, which further helps keep the different files, such as your documents and
-datasets, organized. For example, your "research project" directory may contain
-"documentation", "data", and "code" directories that each contain the relative
-files for your project. For more tips about organizing your digital files, see
-the [UC Davis Library Research Data Management Guide on Directory
-Structures][libguide-directory].
-::::
-:::
-
-[libguide-directory]: https://guides.library.ucdavis.edu/data-management/directories
-
 A **README** is one of the most important documents in your research project.
 The README introduces and explains a project, or the contents of a specific
 directory within a project. READMEs should generally be plain-text (`.txt`) or


### PR DESCRIPTION
This PR restores content about file naming conventions that got cut (perhaps unintentionally?) when we were editing individually. While I think we should link out to other Library resources and avoid reinventing material when possible, I also don't think we should cut content that we already have, especially if it's in agreement with the other resources.

This PR also fixes some formatting problems in and reorganizes the section about naming conventions.

This is meant to be merged after #28.